### PR TITLE
Broadcast with Napa::Representer for the given object if it exists

### DIFF
--- a/lib/napa_rabbit_publisher/rabbit_active_record_callbacks.rb
+++ b/lib/napa_rabbit_publisher/rabbit_active_record_callbacks.rb
@@ -14,7 +14,12 @@ module NapaRabbitPublisher
     def post_to_rabbit(key)
       # broadcast to rabbit
       amqp = NapaRabbitPublisher::AMQPSingleton.instance
-      data = respond_to?(:amqp_properties) ? amqp_properties : self
+      data = {}
+      begin
+        data = "#{self.class.name}Representer".constantize.new(self)
+      rescue NameError => e
+        data = respond_to?(:amqp_properties) ? amqp_properties : self
+      end
       # routing_key = <singular model name>_<past tense action>
       routing_key = "#{self.class.name.underscore}_#{key}"
       amqp.exchange.publish(data.to_json, routing_key: routing_key, content_type: 'application/json')

--- a/napa_rabbit_publisher.gemspec
+++ b/napa_rabbit_publisher.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'bunny'
+  spec.add_dependency 'napa'
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "activerecord", "~> 4.0"

--- a/spec/rabbit_active_record_callbacks_spec.rb
+++ b/spec/rabbit_active_record_callbacks_spec.rb
@@ -1,11 +1,22 @@
 require 'spec_helper'
 require 'active_record'
 require 'napa_rabbit_publisher'
+require 'napa'
 
 describe NapaRabbitPublisher::RabbitActiveRecordCallbacks do
   class Foo < ActiveRecord::Base
     include NapaRabbitPublisher::RabbitActiveRecordCallbacks
   end
+
+  class Bar < ActiveRecord::Base
+    include NapaRabbitPublisher::RabbitActiveRecordCallbacks
+  end
+
+  class BarRepresenter < Napa::Representer
+    property :id, type: String
+    property :name
+  end
+
   ENV['SERVICE_NAME'] = 'test'
 
   context 'when included in an AR model' do
@@ -26,6 +37,16 @@ describe NapaRabbitPublisher::RabbitActiveRecordCallbacks do
         f = Foo.create()
         expect_any_instance_of(Bunny::Exchange).to receive(:publish)
         f.update_attributes(word: :bar)
+      end
+    end
+    context 'when it has a representer' do
+      it 'broadcasts a message with the representer' do
+        expect_any_instance_of(Bunny::Exchange).to receive(:publish) do |method, data, options|
+          obj = JSON.parse(data)
+          expect(obj['id']).to be_a String
+          expect(obj['name']).to eq 'baz'
+        end
+        b = Bar.create(name: 'baz')
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,9 @@ RSpec.configure do |config|
       create_table :foos do |t|
         t.string :word
       end
+      create_table :bars do |t|
+        t.string :name
+      end
     end
 
     class Foo < ActiveRecord::Base


### PR DESCRIPTION
In order to achieve some sort of contract of schema going in/out of Rabbit, use a defined representer for the given object. 
