### PR TITLE
Abstract publishing for reuse

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,12 @@ define the following variables in your ENV
 ENV['SERVICE_NAME'] defines the topic exchange that you will be sending messages through.
 
 ```
-amqp = NapaRabbitPublisher::AMQPSingleton.instance
-data = {i: :like_turtles}
-routing_key = 'meme_quotes'
-amqp.exchange.publish(data.to_json, routing_key: routing_key, content_type: 'application/json')
+data = { foo: 'bar' }
+routing_key = 'foo_created'
+NapaRabbitPublisher.publish(data, routing_key)
 ```
+
+It is assumed that the data argument will be a hash, or something that responds to `.to_json`, and will be broadcast as `content_type: 'application/json'` onto the exchange.
 
 There is also an ActiveRecord module that will broadcast changes to models automatically (using the after_create and after_update hooks)
 

--- a/lib/napa_rabbit_publisher.rb
+++ b/lib/napa_rabbit_publisher.rb
@@ -3,4 +3,9 @@ module NapaRabbitPublisher
   require 'napa_rabbit_publisher/version'
   require 'napa_rabbit_publisher/amqp_singleton'
   require 'napa_rabbit_publisher/rabbit_active_record_callbacks'
+
+  def self.publish(data, routing_key)
+    amqp = NapaRabbitPublisher::AMQPSingleton.instance
+    amqp.exchange.publish(data.to_json, routing_key: routing_key, content_type: 'application/json')
+  end
 end

--- a/lib/napa_rabbit_publisher/rabbit_active_record_callbacks.rb
+++ b/lib/napa_rabbit_publisher/rabbit_active_record_callbacks.rb
@@ -12,12 +12,9 @@ module NapaRabbitPublisher
     end
 
     def post_to_rabbit(key)
-      # broadcast to rabbit
-      amqp = NapaRabbitPublisher::AMQPSingleton.instance
       data = respond_to?(:amqp_properties) ? amqp_properties : self
-      # routing_key = <singular model name>_<past tense action>
       routing_key = "#{self.class.name.underscore}_#{key}"
-      amqp.exchange.publish(data.to_json, routing_key: routing_key, content_type: 'application/json')
+      NapaRabbitPublisher.publish(data, routing_key)
     end
   end
 end


### PR DESCRIPTION
@bellycard/platform 

This will allow us to broadcast to Rabbit outside of the scope ActiveRecord callbacks. 

``` ruby
NapaRabbitPublisher.publish({foo: 'bar'}, routing_key)
```
