### PR TITLE
Post Destroy Events

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Or install it yourself as:
 
 ## Usage
 
-define the following variables in your ENV
+Define the following variables in your ENV:
+
 + AMQP_HOST # ex: amqp://localhost:5672
 + SERVICE_NAME # ex: my-awesome-service
 
@@ -32,7 +33,7 @@ NapaRabbitPublisher.publish(data, routing_key)
 
 It is assumed that the data argument will be a hash, or something that responds to `.to_json`, and will be broadcast as `content_type: 'application/json'` onto the exchange.
 
-There is also an ActiveRecord module that will broadcast changes to models automatically (using the after_create and after_update hooks)
+There is also an ActiveRecord module that will broadcast changes to models automatically (using the `after_create`, `after_update`, and `after_destroy` hooks)
 
 ```
 class User < ActiveRecord::Base

--- a/lib/napa_rabbit_publisher/rabbit_active_record_callbacks.rb
+++ b/lib/napa_rabbit_publisher/rabbit_active_record_callbacks.rb
@@ -3,6 +3,7 @@ module NapaRabbitPublisher
     def self.included(base)
       base.after_commit :post_create_to_rabbit, on: :create
       base.after_commit :post_update_to_rabbit, on: :update
+      base.after_commit :post_destroy_to_rabbit, on: :destroy
     end
 
     def post_create_to_rabbit
@@ -11,6 +12,10 @@ module NapaRabbitPublisher
 
     def post_update_to_rabbit
       post_to_rabbit('updated')
+    end
+
+    def post_destroy_to_rabbit
+      post_to_rabbit('destroy')
     end
 
     def post_to_rabbit(key)

--- a/spec/rabbit_active_record_callbacks_spec.rb
+++ b/spec/rabbit_active_record_callbacks_spec.rb
@@ -21,11 +21,20 @@ describe NapaRabbitPublisher::RabbitActiveRecordCallbacks do
       end
 
     end
+
     context 'when updating a record' do
       it 'broadcasts a message' do
         f = Foo.create()
         expect_any_instance_of(Bunny::Exchange).to receive(:publish)
         f.update_attributes(word: :bar)
+      end
+    end
+
+    context 'when destroying a record' do
+      it 'broadcasts a message' do
+        f = Foo.create()
+        expect_any_instance_of(Bunny::Exchange).to receive(:publish)
+        f.destroy()
       end
     end
   end


### PR DESCRIPTION
Currently only create and update callbacks are being posted to Rabbit as part of this Gem. This PR adds support for posting destroy callbacks to Rabbit as well.

@bellycard/platform
